### PR TITLE
N29: A way to obtain user consent for one-way media and data use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,9 @@ Supporting this use case adds the following requirements:</p>
                    be supported by servers as well as user agents.
    N15             It must be possible to support data exchange
                    in a worker.
+   N29             The application must be able to request user consent
+                   for one-way media and data only use cases in a
+                   non-discriminating way.
 </pre>
 References:
 <ol>
@@ -367,6 +370,9 @@ the use-cases catalogued in this document.</p>
                  rendered.
    N28           TBD: restrictions on the application so as to
                  prevent unauthorized recording of the session.
+   N29           The application must be able to request user consent
+                 for one-way media and data only use cases in a
+                 non-discriminating way.
 </pre>
 </section>
 </section>


### PR DESCRIPTION
Resolves #1

This could also be added to the *Video Conferencing with a Central Server* section.

@steely-glint: Is the wording solid enough to ensure that one really can get the same mode as can be achieved with `getUserMedia`?