### PR TITLE
Clarify particular types of workers that need WebRTC

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@ Supporting this use case adds the following requirements:</p>
         <tr id="N13">
            <td>N13</td>
            <td>It must be possible to support data exchange
-           in a worker.</td>
+           in a web, service, or shared worker.</td>
         </tr>
         <tr id="N24">
            <td>N24</td>
@@ -604,7 +604,7 @@ the use-cases included in this document.</p>
         <tr id="N13">
            <td>N13</td>
            <td>It must be possible to support data exchange
-           in a worker.</td>
+           in a web, service, or shared worker.</td>
         </tr>
         <tr id="N14">
            <td>N14</td>


### PR DESCRIPTION
This is the simplest change I could come up with to at least partly address #60, by specifying that we need WebRTC data transfer in service workers specifically.

I'm also going to put together a version where I add an entire P2P CDN use case, to compare.