### PR TITLE
Remove requirement N36 (and substitute N13)

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,13 +273,13 @@ Supporting this use case adds the following requirements:</p>
            etc.</td>
         </tr>
         <tr>
-           <td>N37</td>
+           <td>N36</td>
            <td>It must be possible for the user agent's receive pipeline to process
            video at high resolution and framerate (e.g. without copying raw video  
            frames).</td>  
         </tr>
         <tr>
-           <td>N38</td>
+           <td>N37</td>
            <td>The application must be able to control the jitter buffer and rendering
            delay.</td>
         </tr>
@@ -307,6 +307,13 @@ transported using WebRTC A/V or RTCDataChannel.</p>
     </thead>
     <tbody>
         <tr>
+           <td>N13</td>
+           <td>It must be possible to support data exchange
+           in a web, service, or shared worker. Support for 
+           service workers allows the page to issue a fetch()
+           which can be resolved in the service worker.</td>
+        </tr>
+        <tr>
            <td>N15</td>
            <td>The application must be able to control aspects
            of the data transport  (e.g. set the SCTP
@@ -314,11 +321,7 @@ transported using WebRTC A/V or RTCDataChannel.</p>
            etc.</td>
         </tr>
         <tr>
-           <td>N36</td>
-           <td>Support for DRM (containerized media) or uncontainerized media.</td>
-        </tr>
-        <tr>
-           <td>N39</td>
+           <td>N38</td>
            <td>A node must be able to forward media received from another node
            to a third node. Applications require access to encoded chunk metadata 
            as well as information from the RTP header to provide for timing, media
@@ -735,23 +738,21 @@ updates of the global model to the clients.</p>
           </tr>
        </thead>
        <tbody>
-           <tr>
-              <td>N40</td>
-              <td>An application can create an outgoing WebRTC connection without activating
-                an encoder.</td>
-           </tr>
-           <tr>
-             <td>N41</td>
-             <td>An application can create encoded video frames from
-             encoded data + metadata,
-             and enqueue them on an outgoing WebRTC connection</td>
-           </tr>
-           <tr>
-             <td>N42</td>
-             <td>The WebRTC connection can generate signals indicating
-             the desired bandwidth and any demands for keyframes, and
-               surface those to the applciation.
-           </tr>
+        <tr id="N39">
+           <td>N40</td>
+           <td>An application can create an outgoing WebRTC connection without activating
+           an encoder.</td>
+        </tr>
+        <tr id="N40">
+           <td>N41</td>
+           <td>An application can create encoded video frames from encoded data + metadata,
+           and enqueue them on an outgoing WebRTC connection</td>
+        </tr>
+        <tr id="N41">
+           <td>N42</td>
+           <td>The WebRTC connection can generate signals indicating the desired bandwidth and
+           any demands for keyframes, and surface those to the application.</td>
+        </tr>
        </tbody>
    </table>  
   
@@ -790,36 +791,28 @@ updates of the global model to the clients.</p>
           </tr>
        </thead>
        <tbody>
-         <tr>
+        <tr id="N40">
            <td>N41</td>
-           <td>
-             An application can create encoded video frames from
-             encoded data + metadata,
-             and enqueue them on an outgoing WebRTC connection
-           </td>
-         </tr>
-         <tr>
+           <td>An application can create encoded video frames from encoded data + metadata,
+           and enqueue them on an outgoing WebRTC connection</td>
+        </tr>
+        <tr id="N41">
            <td>N42</td>
-           <td>The WebRTC connection can generate signals indicating
-             the desired bandwidth and any demands for keyframes, and
-             surface those to the applciation.
-         </tr>
-         <tr>
+           <td>The WebRTC connection can generate signals indicating the desired bandwidth and
+           any demands for keyframes, and surface those to the application.</td>
+        </tr>
+        <tr id="N42">
            <td>N43</td>
-           <td>
-             The application can modify metadata on outgoing frames so that they fit smoothly within
-             the expected sequence of timestamps and sequence numbers.
+           <td>The application can modify metadata on outgoing frames so that they fit smoothly
+           within the expected sequence of timestamps and sequence numbers.
            </td>
-         </tr>
-         <tr>
+        </tr>
+        <tr id="N43">
            <td>N44</td>
-           <td>
-             The application can signal the WebRTC encoder when resuming live transmission in such a way
-             that generated frames fit smoothly within
-             the expected sequence of timestamps and sequence numbers.
-           </td>
-         </tr>
-         
+           <td>The application can signal the WebRTC encoder when resuming live transmission in
+           such a way that generated frames fit smoothly within the expected sequence of
+           timestamps and sequence numbers.</td>
+        </tr>        
        </tbody>
    </table>
 </section>
@@ -1034,21 +1027,17 @@ the use-cases included in this document.</p>
             to multiple group members without re-encoding for each recipient (to reduce resource usage).</td>
         </tr>
         <tr id="N36">
-           <td>N36</td>
-           <td>Support for DRM (containerized media) or uncontainerized media.</td>
-        </tr>
-        <tr id="N37">
            <td>N37</td>
            <td>It must be possible for the user agent's receive pipeline to process
            video at high resolution and framerate (e.g. without copying raw video
            frames).</td>                   
         </tr>
-        <tr id="N38">
+        <tr id="N37">
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
            delay.</td>
         </tr>
-        <tr id="N39">
+        <tr id="N38">
            <td>N39</td>
            <td>A node must be able to forward media received from another node
            to a third node. Applications require access to encoded chunk metadata 
@@ -1056,44 +1045,36 @@ the use-cases included in this document.</p>
            configuration and congestion control. This includes a mechanism
            for a relaying peer to obtain a bandwidth estimate.</td>
         </tr>
-<tr id="N40">
-  <td>N40</td>
-  <td>
-    An application can create an outgoing WebRTC connection without activating
-    an encoder.</td>
-</tr>
-<tr id="N41">
-  <td>N41</td>
-<td>An application can create encoded video frames from
-             encoded data + metadata,
-  and enqueue them on an outgoing WebRTC connection</td>
-</tr>
-<tr id="N42">
-  <td>N42</td>
-  <td>The WebRTC connection can generate signals indicating
-    the desired bandwidth and any demands for keyframes, and
-    surface those to the applciation.
-  </td>
-</tr>
-         <tr id="N43">
+        <tr id="N39">
+           <td>N40</td>
+           <td>An application can create an outgoing WebRTC connection without activating
+           an encoder.</td>
+        </tr>
+        <tr id="N40">
+           <td>N41</td>
+           <td>An application can create encoded video frames from encoded data + metadata,
+           and enqueue them on an outgoing WebRTC connection</td>
+        </tr>
+        <tr id="N41">
+           <td>N42</td>
+           <td>The WebRTC connection can generate signals indicating the desired bandwidth and
+           any demands for keyframes, and surface those to the application.</td>
+        </tr>
+        <tr id="N42">
            <td>N43</td>
-           <td>
-             The application can modify metadata on outgoing frames so that they fit smoothly within
-             the expected sequence of timestamps and sequence numbers.
+           <td>The application can modify metadata on outgoing frames so that they fit smoothly
+           within the expected sequence of timestamps and sequence numbers.
            </td>
-         </tr>
-         <tr id="N44">
+        </tr>
+        <tr id="N43">
            <td>N44</td>
-           <td>
-             The application can signal the WebRTC encoder when resuming live transmission in such a way
-             that generated frames fit smoothly within
-             the expected sequence of timestamps and sequence numbers.
-           </td>
-         </tr>
-
+           <td>The application can signal the WebRTC encoder when resuming live transmission in
+           such a way that generated frames fit smoothly within the expected sequence of
+           timestamps and sequence numbers.</td>
+        </tr>
     </tbody>
 </table>
-<p class="note">Requirements N30-N42 have not completed a Call for Consensus (CfC).</p>
+<p class="note">Requirements N30-N43 have not completed a Call for Consensus (CfC).</p>
 </section>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -738,18 +738,18 @@ updates of the global model to the clients.</p>
           </tr>
        </thead>
        <tbody>
-        <tr id="N39">
-           <td>N40</td>
+        <tr>
+           <td>N39</td>
            <td>An application can create an outgoing WebRTC connection without activating
            an encoder.</td>
         </tr>
-        <tr id="N40">
-           <td>N41</td>
+        <tr>
+           <td>N40</td>
            <td>An application can create encoded video frames from encoded data + metadata,
            and enqueue them on an outgoing WebRTC connection</td>
         </tr>
-        <tr id="N41">
-           <td>N42</td>
+        <tr>
+           <td>N41</td>
            <td>The WebRTC connection can generate signals indicating the desired bandwidth and
            any demands for keyframes, and surface those to the application.</td>
         </tr>
@@ -791,24 +791,24 @@ updates of the global model to the clients.</p>
           </tr>
        </thead>
        <tbody>
-        <tr id="N40">
-           <td>N41</td>
+        <tr>
+           <td>N40</td>
            <td>An application can create encoded video frames from encoded data + metadata,
            and enqueue them on an outgoing WebRTC connection</td>
         </tr>
-        <tr id="N41">
-           <td>N42</td>
+        <tr>
+           <td>N41</td>
            <td>The WebRTC connection can generate signals indicating the desired bandwidth and
            any demands for keyframes, and surface those to the application.</td>
         </tr>
-        <tr id="N42">
-           <td>N43</td>
+        <tr>
+           <td>N42</td>
            <td>The application can modify metadata on outgoing frames so that they fit smoothly
            within the expected sequence of timestamps and sequence numbers.
            </td>
         </tr>
-        <tr id="N43">
-           <td>N44</td>
+        <tr>
+           <td>N43</td>
            <td>The application can signal the WebRTC encoder when resuming live transmission in
            such a way that generated frames fit smoothly within the expected sequence of
            timestamps and sequence numbers.</td>
@@ -1027,18 +1027,18 @@ the use-cases included in this document.</p>
             to multiple group members without re-encoding for each recipient (to reduce resource usage).</td>
         </tr>
         <tr id="N36">
-           <td>N37</td>
+           <td>N36</td>
            <td>It must be possible for the user agent's receive pipeline to process
            video at high resolution and framerate (e.g. without copying raw video
            frames).</td>                   
         </tr>
         <tr id="N37">
-           <td>N38</td>
+           <td>N37</td>
            <td>The application must be able to control the jitter buffer and rendering
            delay.</td>
         </tr>
         <tr id="N38">
-           <td>N39</td>
+           <td>N38</td>
            <td>A node must be able to forward media received from another node
            to a third node. Applications require access to encoded chunk metadata 
            as well as information from the RTP header to provide for timing, media
@@ -1046,28 +1046,28 @@ the use-cases included in this document.</p>
            for a relaying peer to obtain a bandwidth estimate.</td>
         </tr>
         <tr id="N39">
-           <td>N40</td>
+           <td>N39</td>
            <td>An application can create an outgoing WebRTC connection without activating
            an encoder.</td>
         </tr>
         <tr id="N40">
-           <td>N41</td>
+           <td>N40</td>
            <td>An application can create encoded video frames from encoded data + metadata,
            and enqueue them on an outgoing WebRTC connection</td>
         </tr>
         <tr id="N41">
-           <td>N42</td>
+           <td>N41</td>
            <td>The WebRTC connection can generate signals indicating the desired bandwidth and
            any demands for keyframes, and surface those to the application.</td>
         </tr>
         <tr id="N42">
-           <td>N43</td>
+           <td>N42</td>
            <td>The application can modify metadata on outgoing frames so that they fit smoothly
            within the expected sequence of timestamps and sequence numbers.
            </td>
         </tr>
         <tr id="N43">
-           <td>N44</td>
+           <td>N43</td>
            <td>The application can signal the WebRTC encoder when resuming live transmission in
            such a way that generated frames fit smoothly within the expected sequence of
            timestamps and sequence numbers.</td>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-nv-use-cases/issues/86


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/pull/88.html" title="Last updated on Jan 12, 2023, 12:06 AM UTC (5f6a75c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/88/7334bb9...5f6a75c.html" title="Last updated on Jan 12, 2023, 12:06 AM UTC (5f6a75c)">Diff</a>