### PR TITLE
Clarify meaning of "node" in requirement N39

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,8 +319,8 @@ transported using WebRTC A/V or RTCDataChannel.</p>
         </tr>
         <tr>
            <td>N39</td>
-           <td>A node must be able to forward media received from another node
-           to a third node. Applications require access to encoded chunk metadata 
+           <td>A user-agent must be able to forward media received from a peer
+           to another peer. Applications require access to encoded chunk metadata 
            as well as information from the RTP header to provide for timing, media
            configuration and congestion control. This includes a mechanism
            for a relaying peer to obtain a bandwidth estimate.</td>
@@ -1096,8 +1096,8 @@ the use-cases included in this document.</p>
         </tr>
         <tr id="N39">
            <td>N39</td>
-           <td>A node must be able to forward media received from another node
-           to a third node. Applications require access to encoded chunk metadata 
+           <td>A user-agent must be able to forward media received from a peer
+           to another peer. Applications require access to encoded chunk metadata 
            as well as information from the RTP header to provide for timing, media
            configuration and congestion control. This includes a mechanism
            for a relaying peer to obtain a bandwidth estimate.</td>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-nv-use-cases/issues/85


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 20, 2023, 10:41 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebrtc-nv-use-cases%2F2a0cb4ad3f5b8d95fa4a20177320bfb555d0a1e2%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-nv-use-cases%2398.)._
</details>
