### PR TITLE
N15 latency control should be formulated in a technology-agnostic way

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,10 +267,9 @@ Supporting this use case adds the following requirements:</p>
     <tbody>
         <tr>
            <td>N15</td>
-           <td>The application must be able to control aspects
-           of the data transport  (e.g. set the SCTP
-           heartbeat interval or turn it off), RTO values,
-           etc.</td>
+           <td>The application must be able to take steps to ensure a low and consistent
+             latency for audio, video and data under varying network conditions. This may
+             include tweaking of transport parameters for both media and data.</td>
         </tr>
         <tr>
            <td>N37</td>
@@ -308,10 +307,9 @@ transported using WebRTC A/V or RTCDataChannel.</p>
     <tbody>
         <tr>
            <td>N15</td>
-           <td>The application must be able to control aspects
-           of the data transport  (e.g. set the SCTP
-           heartbeat interval or turn it off), RTO values,
-           etc.</td>
+           <td>The application must be able to take steps to ensure a low and consistent
+             latency for audio, video and data under varying network conditions. This may
+             include tweaking of transport parameters for both media and data.</td>
         </tr>
         <tr>
            <td>N36</td>
@@ -355,10 +353,9 @@ following requirements:</p>
         </tr>
         <tr>
            <td>N15</td>
-           <td>The application must be able to control aspects
-           of the data transport  (e.g. set the SCTP
-           heartbeat interval or turn it off), RTO values,
-           etc.</td>
+           <td>The application must be able to take steps to ensure a low and consistent
+             latency for audio, video and data under varying network conditions. This may
+             include tweaking of transport parameters for both media and data.</td>
         </tr>
         <tr>
            <td>N16</td>
@@ -964,10 +961,9 @@ the use-cases included in this document.</p>
         </tr>
         <tr id="N15">
            <td>N15</td>
-           <td>The application must be able to control aspects
-           of the data transport  (e.g. set the SCTP
-           heartbeat interval or turn it off), RTO values,
-           etc.</td>
+           <td>The application must be able to take steps to ensure a low and consistent
+             latency for audio, video and data under varying network conditions. This may
+             include tweaking of transport parameters for both media and data.</td>
         </tr>
         <tr id="N16">
            <td>N16</td>


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-nv-use-cases/issues/91


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 20, 2023, 11:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebrtc-nv-use-cases%2F68790632f9d6ad76341219b02f57369ab06bd4b8%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-nv-use-cases%2399.)._
</details>
