### PR TITLE
Rename "WebRTC-NV Use Cases" to "WebRTC Extended Use Cases"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,25 +4,25 @@
   <meta name="generator" content="HTML Tidy for HTML5 for Linux/x86 version 5.3.9">
   <meta charset="utf-8">
   <link href="webrtc.css" rel="stylesheet">
-  <title>WebRTC Next Version Use Cases</title>
+  <title>WebRTC Extended Use Cases</title>
   <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
   <script src="respec-config.js" class="remove"></script>
 </head>
 <body>
   <section id="abstract">
-    <p>This document describes a set of use cases motivating the development of
-    WebRTC Next Version (WebRTC-NV), as well as the requirements derived from
-    those use cases.</p>
+    <p>This document describes an extended set of use cases motivating the
+    development of additional WebRTC APIs, as well as the requirements derived
+    from those use cases.</p>
   </section>
   <section id="sotd"></section>
   <section id="overview*">
     <h2>Scope and Motivation</h2>
-    <p>To motivate the development of WebRTC 1.0, the IETF RTCWEB WG developed [[?RFC7478]].
-    This document describes use cases motivating the development of
-    "WebRTC Next Version" (WebRTC-NV), and the requirements deriving from those use cases.
+    <p>To motivate the development of WebRTC, the IETF RTCWEB WG developed [[?RFC7478]].
+    This document describes extended use cases motivating the development of additional
+    WebRTC APIs and the requirements deriving from those use cases.
     The use cases fall into one of two categories:
     enhancements to use cases already covered in [[?RFC7478]], and
-    new use cases which are not supported in WebRTC 1.0 [[?WEBRTC]] without extensions.</p>
+    new use cases which are not supported in WebRTC [[?WEBRTC]] without extensions.</p>
    </section>
    <section id="existingusecases*">
     <h2>Existing Use Cases</h2>


### PR DESCRIPTION
Rename the document formerly known as "WebRTC-NV Use Cases", and provide explanatory text explaining the new name.

Fixes https://github.com/w3c/webrtc-nv-use-cases/issues/107


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/pull/108.html" title="Last updated on Mar 29, 2023, 8:25 PM UTC (0ecb669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/108/69f874d...0ecb669.html" title="Last updated on Mar 29, 2023, 8:25 PM UTC (0ecb669)">Diff</a>