### PR TITLE
Section 3.2.1: Add N48 - bandwidth feedback speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,14 @@ Supporting this use case adds the following requirements:</p>
            delay. This requirement is addressed by jitterBufferTarget, defined in
            [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
+	<tr>
+           <td>N48</td>
+           <td>The application should be designed to offer suggestions for
+           timing parameter preferences to the User Agent (UA). This allows
+           the application to contribute to the management of packet loss
+           and optimization of packet reception timing without interfering
+           with UA congestion control algorithms.</td>
+	</tr>
     </tbody>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
@@ -1068,9 +1076,17 @@ the use-cases included in this document.</p>
            <td>The WebRTC connection can generate signals indicating demands
            for keyframes, and surface those to the application.</td>
         </tr>
+        <tr id="N48">
+           <td>N48</td>
+           <td>The application should be designed to offer suggestions for
+           timing parameter preferences to the User Agent (UA). This allows
+           the application to contribute to the management of packet loss
+           and optimization of packet reception timing without interfering
+           with UA congestion control algorithms.</td>
+        </tr>
     </tbody>
 </table>
-<p class="note">Requirements N40-N47 have unresolved comments from a Call for Consensus (CfC).</p>
+<p class="note">Requirements N40-N48 have unresolved comments from a Call for Consensus (CfC).</p>
 </section>
 </body>
 </html>


### PR DESCRIPTION
Partial fixes for https://github.com/w3c/webrtc-nv-use-cases/issues/103


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xingri/webrtc-nv-use-cases/pull/118.html" title="Last updated on May 8, 2024, 11:54 PM UTC (3a41ab5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/118/01017e8...xingri:3a41ab5.html" title="Last updated on May 8, 2024, 11:54 PM UTC (3a41ab5)">Diff</a>