### PR TITLE
Section 3.2:  Streaming should not require user prompts without sending media

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,13 @@ Supporting this use case adds the following requirements:</p>
            <td>The application must be able to control the jitter buffer and rendering
            delay.</td>
         </tr>
+        <tr>
+           <td>N48</td>
+           <td>The application can operate normally without any user prompts, including camera
+           and microphone permission requests.
+           The application may request user prompts to provide additional services like in-game chatting,
+	   but it is not mandatory to support the application.</td>
+        </tr>
     </tbody>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
@@ -1051,6 +1058,11 @@ the use-cases included in this document.</p>
            <td>N47</td>
            <td>The WebRTC connection can generate signals indicating demands
            for keyframes, and surface those to the application.</td>
+        </tr>
+        <tr id="N48">
+           <td>N48</td>
+           <td>An application can operate normally without any user prompts,
+           including camera and microphone permission requests.</td>
         </tr>
     </tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -283,10 +283,8 @@ Supporting this use case adds the following requirements:</p>
         </tr>
 	<tr>
            <td>N36</td>
-           <td>The application can operate normally without any user prompts, including camera
-           and microphone permission requests.
-           The application may request user prompts to provide additional services like in-game chatting,
-	   but it is not mandatory to support the application.</td>
+           <td>An application that is only receiving but not sending media can operate
+	       without prompts for camera and microphone permissions.</td>
         </tr>
         <tr>
            <td>N37</td>
@@ -996,10 +994,11 @@ the use-cases included in this document.</p>
         <td>A group member can encrypt and send copies of the realtime encoded media directly
             to multiple group members without re-encoding for each recipient (to reduce resource usage).</td>
         </tr>
+        </tr>
 	<tr id="N36">
            <td>N36</td>
-           <td>An application can operate normally without any user prompts,
-           including camera and microphone permission requests.</td>
+           <td>An application that is only receiving but not sending media can operate
+	       without prompts for camera and microphone permissions.</td>
         </tr>
         <tr id="N37">
            <td>N37</td>

--- a/index.html
+++ b/index.html
@@ -283,8 +283,8 @@ Supporting this use case adds the following requirements:</p>
         </tr>
 	<tr>
            <td>N36</td>
-           <td>An application that is only receiving but not sending media can operate
-	       without prompts for camera and microphone permissions.</td>
+           <td>An application that is only receiving but not sending media or data can operate
+	       without access to camera or microphone.</td>
         </tr>
         <tr>
            <td>N37</td>

--- a/index.html
+++ b/index.html
@@ -997,8 +997,8 @@ the use-cases included in this document.</p>
         </tr>
 	<tr id="N36">
            <td>N36</td>
-           <td>An application that is only receiving but not sending media can operate
-	       without prompts for camera and microphone permissions.</td>
+           <td>An application that is only receiving but not sending media or data can operate
+	       without access to camera or microphone.</td>
         </tr>
         <tr id="N37">
            <td>N37</td>

--- a/index.html
+++ b/index.html
@@ -281,6 +281,13 @@ Supporting this use case adds the following requirements:</p>
              latency for audio, video and data under varying network conditions. This may
              include tweaking of transport parameters for both media and data.</td>
         </tr>
+	<tr>
+           <td>N36</td>
+           <td>The application can operate normally without any user prompts, including camera
+           and microphone permission requests.
+           The application may request user prompts to provide additional services like in-game chatting,
+	   but it is not mandatory to support the application.</td>
+        </tr>
         <tr>
            <td>N37</td>
            <td>It must be possible for the user agent's receive pipeline to process
@@ -291,13 +298,6 @@ Supporting this use case adds the following requirements:</p>
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
            delay.</td>
-        </tr>
-        <tr>
-           <td>N48</td>
-           <td>The application can operate normally without any user prompts, including camera
-           and microphone permission requests.
-           The application may request user prompts to provide additional services like in-game chatting,
-	   but it is not mandatory to support the application.</td>
         </tr>
     </tbody>
 </table>
@@ -996,6 +996,11 @@ the use-cases included in this document.</p>
         <td>A group member can encrypt and send copies of the realtime encoded media directly
             to multiple group members without re-encoding for each recipient (to reduce resource usage).</td>
         </tr>
+	<tr id="N36">
+           <td>N36</td>
+           <td>An application can operate normally without any user prompts,
+           including camera and microphone permission requests.</td>
+        </tr>
         <tr id="N37">
            <td>N37</td>
            <td>It must be possible for the user agent's receive pipeline to process
@@ -1058,11 +1063,6 @@ the use-cases included in this document.</p>
            <td>N47</td>
            <td>The WebRTC connection can generate signals indicating demands
            for keyframes, and surface those to the application.</td>
-        </tr>
-        <tr id="N48">
-           <td>N48</td>
-           <td>An application can operate normally without any user prompts,
-           including camera and microphone permission requests.</td>
         </tr>
     </tbody>
 </table>

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@ Supporting this use case adds the following requirements:</p>
 	<tr>
            <td>N36</td>
            <td>An application that is only receiving but not sending media or data can operate
-	       without access to camera or microphone.</td>
+	       efficiently without access to camera or microphone.</td>
         </tr>
         <tr>
            <td>N37</td>
@@ -998,7 +998,7 @@ the use-cases included in this document.</p>
 	<tr id="N36">
            <td>N36</td>
            <td>An application that is only receiving but not sending media or data can operate
-	       without access to camera or microphone.</td>
+	       efficiently without access to camera or microphone.</td>
         </tr>
         <tr id="N37">
            <td>N37</td>


### PR DESCRIPTION
Add the constraints to Cloud Gaming application that allow users to use the application without accessing any user media resources.

Partial fixes for https://github.com/w3c/webrtc-nv-use-cases/issues/103


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xingri/webrtc-nv-use-cases/pull/119.html" title="Last updated on Jul 27, 2023, 3:01 PM UTC (be292ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/119/b1e964c...xingri:be292ac.html" title="Last updated on Jul 27, 2023, 3:01 PM UTC (be292ac)">Diff</a>