### PR TITLE
Requirement N38 is satisfied by jitterBufferTarget

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,13 +295,13 @@ Supporting this use case adds the following requirements:</p>
         <tr>
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
-           delay.</td>
+           delay. This requirement is satisfied by jitterBufferTarget, defined in
+           [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
     </tbody>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
 transported using RTP or RTCDataChannel.</p>
-<p class="note">Requirement N38 is satisfied by jitterBufferTarget, defined in [[?WebRTC-Extensions]] Section 6.</p>
 </section> 
 <section id="auction">
    <h4>Low latency Broadcast with Fanout</h4>
@@ -1010,7 +1010,8 @@ the use-cases included in this document.</p>
         <tr id="N38">
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
-           delay.</td>
+           delay. This requirement is satisfied by jitterBufferTarget, defined in
+           [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
         <tr id="N39">
            <td>N39</td>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,7 @@ Supporting this use case adds the following requirements:</p>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
 transported using RTP or RTCDataChannel.</p>
+<p class="note">Requirement N38 is satisfied by jitterBufferTarget, defined in [[?WebRTC-Extensions]] Section 6.2.</p>
 </section> 
 <section id="auction">
    <h4>Low latency Broadcast with Fanout</h4>

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@ Supporting this use case adds the following requirements:</p>
         <tr>
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
-           delay. This requirement is satisfied by jitterBufferTarget, defined in
+           delay. This requirement is addressed by jitterBufferTarget, defined in
            [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
     </tbody>
@@ -1010,7 +1010,7 @@ the use-cases included in this document.</p>
         <tr id="N38">
            <td>N38</td>
            <td>The application must be able to control the jitter buffer and rendering
-           delay. This requirement is satisfied by jitterBufferTarget, defined in
+           delay. This requirement is addressed by jitterBufferTarget, defined in
            [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
         <tr id="N39">

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ Supporting this use case adds the following requirements:</p>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
 transported using RTP or RTCDataChannel.</p>
-<p class="note">Requirement N38 is satisfied by jitterBufferTarget, defined in [[?WebRTC-Extensions]] Section 6.2.</p>
+<p class="note">Requirement N38 is satisfied by jitterBufferTarget, defined in [[?WebRTC-Extensions]] Section 6.</p>
 </section> 
 <section id="auction">
    <h4>Low latency Broadcast with Fanout</h4>


### PR DESCRIPTION
Add a note explaining that requirement N38 is satisfied by jitterBufferTarget.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/pull/124.html" title="Last updated on Oct 19, 2023, 2:51 PM UTC (45d33e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/124/31642e5...45d33e2.html" title="Last updated on Oct 19, 2023, 2:51 PM UTC (45d33e2)">Diff</a>