### PR TITLE
Made N42 and N47 orthogonal.

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,8 +671,7 @@ requirements:</p>
         <tr>
            <td>N42</td>
            <td>The WebRTC connection can generate signals indicating the desired
-           bandwidth and any demands for keyframes, and surface those to the
-           application.</td>
+           bandwidth, and surface those to the application.</td>
         </tr>
        </tbody>
    </table>  
@@ -716,8 +715,7 @@ requirements:</p>
         <tr>
            <td>N42</td>
            <td>The WebRTC connection can generate signals indicating the desired
-           bandwidth and any demands for keyframes, and surface those to the
-           application.</td>
+           bandwidth, and surface those to the application.</td>
         </tr>
         <tr>
            <td>N43</td>
@@ -1040,8 +1038,7 @@ the use-cases included in this document.</p>
         <tr id="N42">
            <td>N42</td>
            <td>The WebRTC connection can generate signals indicating the desired
-           bandwidth and any demands for keyframes, and surface those to the
-           application.</td>
+           bandwidth, and surface those to the application.</td>
         </tr>
         <tr id="N43">
            <td>N43</td>


### PR DESCRIPTION
Fix for #127.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stefhak/webrtc-nv-use-cases/pull/128.html" title="Last updated on Dec 13, 2023, 3:54 PM UTC (851d8a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/128/a2b72f2...stefhak:851d8a2.html" title="Last updated on Dec 13, 2023, 3:54 PM UTC (851d8a2)">Diff</a>