### PR TITLE
Section 3.2.1: Add N49 - video decoding recovery after packet loss

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,13 @@ Supporting this use case adds the following requirements:</p>
            delay. This requirement is addressed by jitterBufferTarget, defined in
            [[?WebRTC-Extensions]] Section 6.</td>
         </tr>
+        <tr>
+           <td>N49</td>
+           <td>The application should be designed with a flexible video decoding
+           recovery system. This system must ensure uninterrupted decoding operations,
+           capable of handling frame-loss scenarios efficiently without the exclusive
+           reliance on key frames for recovery.<td>
+	</tr>
     </tbody>
 </table>
 <p>Experience: Microsoft's Xbox Cloud Gaming and NVIDIA's GeForce NOW are examples of this use case, with media
@@ -1071,9 +1078,16 @@ the use-cases included in this document.</p>
            <td>The WebRTC connection can generate signals indicating demands
            for keyframes, and surface those to the application.</td>
         </tr>
+        <tr id="N49">
+           <td>N49</td>
+           <td>The application should be designed with a flexible video decoding
+           recovery system. This system must ensure uninterrupted decoding operations,
+           capable of handling frame-loss scenarios efficiently without the exclusive
+           reliance on key frames for recovery.<td>
+        </tr>
     </tbody>
 </table>
-<p class="note">Requirements N40-N47 have unresolved comments from a Call for Consensus (CfC).</p>
+<p class="note">Requirements N40-N49 have unresolved comments from a Call for Consensus (CfC).</p>
 </section>
 </body>
 </html>


### PR DESCRIPTION
Partial fixes for #103


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xingri/webrtc-nv-use-cases/pull/129.html" title="Last updated on Mar 31, 2024, 9:12 PM UTC (c64bc08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-nv-use-cases/129/3ca2396...xingri:c64bc08.html" title="Last updated on Mar 31, 2024, 9:12 PM UTC (c64bc08)">Diff</a>